### PR TITLE
Add option to discard referrer on invalid origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ bundle exec rails db:migrate
 
 Redirectr::ReferrerToken has two representations: #to_s displays the URL and #to_param its tokenized form. Depending on your config, this can be either a random token, an encrypted URL or the plaintext URL.
 
+### Graceful Handling of Invalid Referrer Origins
+
+Redirectr normally raises `Redirectr::InvalidReferrerToken` when the referrer’s origin (host/protocol/port) is not allowed. If you prefer to **treat such cases as if no referrer was provided**, enable:
+
+```ruby
+YourApp::Application.configure do
+  config.x.redirectr.discard_referrer_on_invalid_origin = true
+end
+```
+
+With this option, `referrer_url` returns `nil` for invalid origins rather than raising an exception, so any code using it naturally falls back to its own default handling.
+
 ## Contributions
 
 Contributions like bugfixes and new ideas are more than welcome. Please just fork this project on github (https://github.com/wvk/redirectr) and send me a pull request with your changes.

--- a/lib/redirectr.rb
+++ b/lib/redirectr.rb
@@ -176,6 +176,8 @@ module Redirectr
         referrer_token
       elsif parsed_url.relative?
         referrer_token
+      elsif Redirectr.config.discard_referrer_on_invalid_origin
+        nil
       else
         raise Redirectr::UrlNotInWhitelist, "#{parsed_url.inspect} - #{redirect_whitelist.inspect}"
       end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -19,8 +19,13 @@ class NavigationTest < ActionDispatch::IntegrationTest
   end
 
   test 'origin checks' do
-    get '/redirect?referrer=http://www.notvalid.com/?foo=bar'
-    assert response.status == 500
+
+    begin
+      get '/redirect?referrer=http://www.notvalid.com/?foo=bar'
+      assert response.status == 500
+    rescue Redirectr::UrlNotInWhitelist # Rails 7.1 throws an exception, Rails 7.2+ returns 500...
+      assert true
+    end
 
     Redirectr.config.discard_referrer_on_invalid_origin = true
     get '/redirect?referrer=http://www.notvalid.com/?foo=bar'

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -17,4 +17,16 @@ class NavigationTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_equal 'http://www.example.com/?other_default=1', request.url
   end
+
+  test 'origin checks' do
+    get '/redirect?referrer=http://www.notvalid.com/?foo=bar'
+    assert response.status == 500
+
+    Redirectr.config.discard_referrer_on_invalid_origin = true
+    get '/redirect?referrer=http://www.notvalid.com/?foo=bar'
+    follow_redirect!
+    assert_equal 'http://www.example.com/?this_is_default_url=1', request.url
+  ensure
+    Redirectr.config.discard_referrer_on_invalid_origin = nil
+  end
 end


### PR DESCRIPTION
This adds the configuration option `discard_referrer_on_invalid_origin`.
When enabled, `referrer_url` returns `nil` for referrers whose origin is not whitelisted instead of raising an exception. 